### PR TITLE
Diploma under intro message

### DIFF
--- a/frontend/src/components/anchor/anchorSection.css
+++ b/frontend/src/components/anchor/anchorSection.css
@@ -34,6 +34,9 @@
     margin: auto;
     left: 0;
     right: 0;
+    font-family: var(--theme-font);
+    text-shadow: var(--theme-text-shadow);
+    font-size: 1.2rem;
 }
 
 .anchor-button p {

--- a/frontend/src/components/projectSection/imageCard.css
+++ b/frontend/src/components/projectSection/imageCard.css
@@ -1,0 +1,20 @@
+.image-card-thumbnail {
+    width: 100%;
+    max-width: 800px;
+    min-width: 300px;
+    height: auto;
+    transition: box-shadow 0.5s ease;
+}
+
+.image-card-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+
+.image-card-thumbnail-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/frontend/src/components/projectSection/imageCard.tsx
+++ b/frontend/src/components/projectSection/imageCard.tsx
@@ -1,0 +1,31 @@
+import { Component } from 'react';
+import { InView } from 'react-intersection-observer';
+import "./projectCard.css";
+import "./imageCard.css";
+
+interface ImageCardProps {
+    thumbnail: string,
+    projectlink: string,
+}
+
+
+export default class ImageCard extends Component<ImageCardProps>{
+
+    constructor(props: ImageCardProps) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <div className="image-card-container">
+                <div className="project-card">
+                    <div className="project-card-thumbnail-container">
+                        <a href={this.props.projectlink} target="_blank" rel="noopener noreferrer">
+                            <img src={this.props.thumbnail} className="image-card-thumbnail" />
+                        </a>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/frontend/src/pages/home/home.tsx
+++ b/frontend/src/pages/home/home.tsx
@@ -294,6 +294,7 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
                     <ImageCard
                         projectlink="https://cdn.discordapp.com/attachments/745465408848527360/858470646824566814/diploma_final.png"
                         thumbnail="https://cdn.discordapp.com/attachments/745465408848527360/858470646824566814/diploma_final.png" />
+                    <div style={{ height: "5rem" }} />
                     <AnchorStandaloneBotan anchor={Anchors[0]} position={AnchorSectionPosition.LEFT} />
                     <div style={{ height: "5rem" }} />
                     <AnchorSupportedSection anchor={Anchors[0]} onVisible={this.onAnchorVisible}>

--- a/frontend/src/pages/home/home.tsx
+++ b/frontend/src/pages/home/home.tsx
@@ -23,6 +23,7 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import AnchorStandaloneBotan from "../../components/anchor/anchorStandaloneBotan";
 
 import ProjectCard from '../../components/projectSection/projectCard';
+import ImageCard from '../../components/projectSection/imageCard';
 import FadeIn from '../../components/fadeInSection/fadeInSection';
 
 //Thumbnails
@@ -284,13 +285,16 @@ export default class HomePage extends React.Component<HomePageProps, HomePageSta
                 <div>
                     <div className="home-hidden-text">Fix home-header from clipping when reloading the page while at topmost or first time load the site</div>
                     <div className="home-header fade-in">
-                        <h1 className="home-header-title">Dear Coco,</h1>
+                        <h1 className="home-header-title">Dear Coco</h1>
                         <div className="home-header-text">
-                            Dear Coco, 
                             You are one of the most remarkable people we have ever known. Your amazing contributions to the community have brought countless overseas viewers down the rabbit hole and, although we are saddened by your decision to graduate, we will always remember and support you. May you fly to ever greater heights.
+                            <br/><br/>For your work, we would like to present you this honorary degree for the Master of Kusa.
                         </div>
-                        <AnchorStandaloneBotan anchor={Anchors[0]} position={AnchorSectionPosition.LEFT} />
                     </div>
+                    <ImageCard
+                        projectlink="https://cdn.discordapp.com/attachments/745465408848527360/858470646824566814/diploma_final.png"
+                        thumbnail="https://cdn.discordapp.com/attachments/745465408848527360/858470646824566814/diploma_final.png" />
+                    <AnchorStandaloneBotan anchor={Anchors[0]} position={AnchorSectionPosition.LEFT} />
                     <div style={{ height: "5rem" }} />
                     <AnchorSupportedSection anchor={Anchors[0]} onVisible={this.onAnchorVisible}>
                         <div className="project-card-section">


### PR DESCRIPTION
Creates a somewhat one-off spin off of projectCard called imageCard using much of the same CSS to insert the Coco diploma.

Moved the anchor botan out of the header along with diploma since it was messing with the margins of the header text.