### PR TITLE
Fix card clipping during fade-in-slide-up animation

### DIFF
--- a/frontend/src/shared/components/baseCard/baseCard.css
+++ b/frontend/src/shared/components/baseCard/baseCard.css
@@ -47,8 +47,9 @@
     align-items: flex-start;
     /* overflow is required to keep cards 
      * from segmenting into different columns 
-     * at certain resolutions */
-    overflow: auto;
+     * at certain resolutions; setting it to
+     * visible prevents the card from clipping */
+    overflow: visible;
     height: 100%;
     scrollbar-width: none;
 }

--- a/frontend/src/shared/components/baseCard/baseCard.css
+++ b/frontend/src/shared/components/baseCard/baseCard.css
@@ -49,7 +49,7 @@
      * from segmenting into different columns 
      * at certain resolutions; setting it to
      * visible prevents the card from clipping */
-    overflow: visible;
+    overflow: auto;
     height: 100%;
     scrollbar-width: none;
 }

--- a/frontend/src/shared/components/baseCard/baseCard.tsx
+++ b/frontend/src/shared/components/baseCard/baseCard.tsx
@@ -47,18 +47,16 @@ export default class BaseCard<T, P extends BaseCardProps<T>, S extends BaseCardS
             backgroundImage: `url(${CardStyles[this.cardStyleIndex][0]})`,
         };
         return (
-            <FadeIn className="fade-in fade-in-expand">
-                <InView className={"base-card"} onChange={this.toggleVisibility.bind(this)} skip={loaded} threshold={.8}>
-                    <div className="card-header" />
-                    <div className="card-header-decal-wrapper">
-                        <div className="card-header-decal" style={rootStyles} />
-                    </div>
-                    <div className="card-content">
-                        {content}
-                    </div>
-                    <div className="card-footer" />
-                </InView>
-            </FadeIn>
+            <InView className={"base-card"} onChange={this.toggleVisibility.bind(this)} skip={loaded} threshold={.8}>
+                <div className="card-header" />
+                <div className="card-header-decal-wrapper">
+                    <div className="card-header-decal" style={rootStyles} />
+                </div>
+                <div className="card-content">
+                    {content}
+                </div>
+                <div className="card-footer" />
+            </InView>
         );
     }
 }

--- a/frontend/src/shared/components/baseSection/baseSection.tsx
+++ b/frontend/src/shared/components/baseSection/baseSection.tsx
@@ -4,6 +4,7 @@ import { Announcement } from "../../../models/announcement";
 import { LanguageContext, LanguageContextValue } from "../../../components/languageSwitch/languageContext";
 import DisplayedLanguage from "../../../models/language";
 import { CardStyles } from "../../../shared/components/baseCard/baseCard";
+import FadeIn from '../../../components/fadeInSection/fadeInSection';
 import './baseSection.css'
 
 export interface BaseSectionProps<T> {
@@ -34,12 +35,16 @@ export default abstract class BaseSection<T> extends React.Component<BaseSection
                         return <div className="base-empty-message">Nothing here yet! Check back later!</div>
                     } else {
                         return (
-                            <div className={sectionStyle}>
-                                {this.props.data.map((object: T, idx: number) => {
-                                    return this.renderCard(object, idx % CardStyles.length, language, idx)
-                                }
-                                )}
-                            </div>
+                                <div className={sectionStyle}>
+                                    {this.props.data.map((object: T, idx: number) => {
+                                        return (
+                                            <FadeIn className="fade-in fade-in-expand">
+                                                {this.renderCard(object, idx % CardStyles.length, language, idx)}
+                                            </FadeIn>
+                                               )
+                                    }
+                                    )}
+                                </div>
                         );
                     }
                 }}


### PR DESCRIPTION
This fixes that horrible mess by changing `.card-section`'s `overflow` to `visible`. It is noted that the `overflow` property is there to prevent *something*, and I believe that setting it to `visible` still satisfies that condition while making sure that the card is not clipped when it is outside the bounds of the `.card-section` box thing.

Fixes #32 as well, since it is related to the card clipping issue.

Please test this; I am not entirely confident that this doesn't break anything.