### PR TITLE
Cleanup and refactor BaseCard, BaseSection, and FadeIn

### DIFF
--- a/frontend/src/components/fadeInSection/fadeInSection.tsx
+++ b/frontend/src/components/fadeInSection/fadeInSection.tsx
@@ -28,10 +28,8 @@ export default class FadeIn extends Component<FadeInProps> {
 
     render() {
         return (
-            <InView className="fade-in-expand" onChange={(inView, entry) => this.triggerAnimation(inView)} triggerOnce={true}>
-                <div className={this.state.animationClass}>
-                    {this.props.children}
-                </div>
+            <InView className={"fade-in-expand " + this.state.animationClass} onChange={(inView, entry) => this.triggerAnimation(inView)} triggerOnce={true}>
+                {this.props.children}
             </InView>
         );
     }

--- a/frontend/src/shared/components/baseCard/baseCard.tsx
+++ b/frontend/src/shared/components/baseCard/baseCard.tsx
@@ -47,7 +47,7 @@ export default class BaseCard<T, P extends BaseCardProps<T>, S extends BaseCardS
             backgroundImage: `url(${CardStyles[this.cardStyleIndex][0]})`,
         };
         return (
-            <InView className={"base-card"} onChange={this.toggleVisibility.bind(this)} skip={loaded} threshold={.8}>
+            <div className="base-card">
                 <div className="card-header" />
                 <div className="card-header-decal-wrapper">
                     <div className="card-header-decal" style={rootStyles} />
@@ -56,7 +56,7 @@ export default class BaseCard<T, P extends BaseCardProps<T>, S extends BaseCardS
                     {content}
                 </div>
                 <div className="card-footer" />
-            </InView>
+            </div>
         );
     }
 }

--- a/frontend/src/shared/components/baseSection/baseSection.tsx
+++ b/frontend/src/shared/components/baseSection/baseSection.tsx
@@ -38,7 +38,7 @@ export default abstract class BaseSection<T> extends React.Component<BaseSection
                                 <div className={sectionStyle}>
                                     {this.props.data.map((object: T, idx: number) => {
                                         return (
-                                            <FadeIn className="fade-in fade-in-expand">
+                                            <FadeIn className="fade-in">
                                                 {this.renderCard(object, idx % CardStyles.length, language, idx)}
                                             </FadeIn>
                                                )


### PR DESCRIPTION
`BaseCard`
- `InView` has been removed and replaced with a plain `div`, because as far as I can tell, it (and the state it modifies, `loaded`) isn't used anywhere directly. Multiple components extend `BaseCard` but to my knowledge none of them use `loaded` directly, or not use `renderCard()`.

`FadeIn`
- The extra `div` inside `InView` has been replaced to applying the `animationClass` directly in the `InView` component. This removes a `div` while not really affecting anything (so far, I hope).

`BaseSection`
- This has been modified to follow the changes in `FadeIn`.