### PR TITLE
Fix warnings

### DIFF
--- a/frontend/src/components/anchor/anchorMultipleSection.tsx
+++ b/frontend/src/components/anchor/anchorMultipleSection.tsx
@@ -25,7 +25,7 @@ export default class AnchorMultipleSection extends React.Component<AnchorMultipl
         activeHrefs = activeHrefs.sort((a, b) => a.lastUpdate > b.lastUpdate ? -1 : 1);
 
         const activeClass = activeHrefs.length > 0 && activeHrefs[0].href === anchor.href ? "active" : "";
-        const lastClass = index == anchors.length - 1 ? " last" : "";
+        const lastClass = index === anchors.length - 1 ? " last" : "";
 
         return (
             <div key={anchor.href} className={activeClass + lastClass}>

--- a/frontend/src/components/comboSection/comboSection.tsx
+++ b/frontend/src/components/comboSection/comboSection.tsx
@@ -6,21 +6,12 @@ import ArtworkCard from '../gallery/artworkCard/artworkCard';
 import MultiArtworkCard from '../gallery/artworkCard/multiArtworkCard';
 import VideoCard from '../videoSection/videoCard';
 import MessageCard from "../messageSection/messageCard/messageCard";
-import BaseSection, { BaseSectionProps, BaseSectionState } from "../../shared/components/baseSection/baseSection";
+import BaseSection from "../../shared/components/baseSection/baseSection";
 import { CardStyles } from "../../shared/components/baseCard/baseCard";
 
 import './comboSection.css';
 
-interface ComboSectionProps extends BaseSectionProps<Message | Artwork | Video> {
-}
-
-interface ComboSectionState extends BaseSectionState {
-
-}
-
 export default class ComboSection extends BaseSection<Message | Artwork | Video | MultiArtwork> {
-
-
     renderCard(object: (Message | Artwork | Video | MultiArtwork), cardStyleIndex: number, language: DisplayedLanguage, id: number): JSX.Element {
         // TODO: messagecard-center might not used or needed
         if ("messageID" in object) {

--- a/frontend/src/components/fadeInSection/fadeInSection.tsx
+++ b/frontend/src/components/fadeInSection/fadeInSection.tsx
@@ -12,11 +12,6 @@ interface FadeInState {
 }
 
 export default class FadeIn extends Component<FadeInProps> {
-
-    constructor(props: FadeInProps) {
-        super(props);
-    }
-
     state = {
         animationClass: 'hidden',
     } as FadeInState

--- a/frontend/src/components/modals/credits/creditsModal/creditsModalButton.tsx
+++ b/frontend/src/components/modals/credits/creditsModal/creditsModalButton.tsx
@@ -3,20 +3,8 @@ import {BaseButtonProps, BaseButtonState} from "../../../../shared/components/bu
 import {NavButton} from "../../../../shared/components/buttons/navButton/navButton";
 import InfoIcon from "@material-ui/icons/Info";
 
-interface CreditsModalButtonProps extends BaseButtonProps {
-
-}
-
-interface CreditsModalButtonState extends BaseButtonState {
-
-}
-
 export default class CreditsModalButton extends Component<BaseButtonProps, BaseButtonState> {
-    readonly creditsButtonContent = "Credits"
-
-    constructor(props: CreditsModalButtonProps) {
-        super(props);
-    }
+    readonly creditsButtonContent = "Credits";
 
     render() {
         return <NavButton className="global-font global-bold" onClick={this.props.onClick} variant="contained" startIcon={<InfoIcon />} size="large" color="primary">

--- a/frontend/src/components/projectSection/imageCard.tsx
+++ b/frontend/src/components/projectSection/imageCard.tsx
@@ -1,5 +1,4 @@
 import { Component } from 'react';
-import { InView } from 'react-intersection-observer';
 import { Launch, Close } from "@material-ui/icons";
 import "./projectCard.css";
 import "./imageCard.css";
@@ -65,11 +64,12 @@ export default class ImageCard extends Component<ImageCardProps>{
                     <div className="project-card-thumbnail-container">
                         <img id={this.props.imageId} className="image-card-thumbnail"
                             src={this.props.thumbnail}
+                            alt={this.props.modalCaption}
                             onClick={this.renderImgModal}/>
                         <div id={this.modalId} className="modal" onClick={this.renderImgModal}>
                             <Close className="close" />
                             <Launch className="pop-out" onClick={this.openWithPrintDialogue} />
-                            <img id={this.modalImgSrcId} className="modal-content" src="" />
+                            <img id={this.modalImgSrcId} className="modal-content" src="" alt={this.props.modalCaption} />
                             <div id={this.modalCaptionId}></div>
                         </div>
                     </div>

--- a/frontend/src/components/projectSection/projectCard.tsx
+++ b/frontend/src/components/projectSection/projectCard.tsx
@@ -1,5 +1,4 @@
-import React, { Component } from 'react';
-import { InView } from 'react-intersection-observer';
+import { Component } from 'react';
 import "./projectCard.css";
 
 interface ProjectCardProps {
@@ -10,13 +9,7 @@ interface ProjectCardProps {
     projectlink: string,
 }
 
-
 export default class ProjectCard extends Component<ProjectCardProps>{
-
-    constructor(props: ProjectCardProps) {
-        super(props);
-    }
-
     isEmbedYoutubeLink(link: string): boolean {
         return link.includes('youtube') && link.includes('embed');
     }
@@ -25,7 +18,8 @@ export default class ProjectCard extends Component<ProjectCardProps>{
         if (this.isEmbedYoutubeLink(this.props.projectlink)) {
             return (
                 <iframe src={this.props.projectlink}
-                        allowFullScreen className="project-card-content project-card-video"/>
+                        allowFullScreen className="project-card-content project-card-video"
+                        title={this.props.title} />
             )
         } else {
             return (

--- a/frontend/src/components/videoSection/videoCard.tsx
+++ b/frontend/src/components/videoSection/videoCard.tsx
@@ -63,7 +63,6 @@ export default class VideoCard extends BaseCard<Video, VideoCardProps, VideoCard
     }
 
     renderVideo() {
-        const hasLoaded = this.state.loadingState === ImageLoadingState.Loaded;
         const videoLink = linkToString(this.video.videoLink);
         const artistLink = this.video.artistLink ? linkToString(this.video.artistLink) : "#no_artist_link";
 

--- a/frontend/src/pages/home/home.tsx
+++ b/frontend/src/pages/home/home.tsx
@@ -15,7 +15,6 @@ import ImageCard from '../../components/projectSection/imageCard';
 import FadeIn from '../../components/fadeInSection/fadeInSection';
 
 //Thumbnails
-import Project1Thumb from '../../assets/thumbnails/Goodbye_Coco_thumbnail-Revel.jpg';
 import Project2Thumb from '../../assets/thumbnails/Cocos_Scrapbook_Cover-Capt-Jules.jpg';
 import Project4Thumb from '../../assets/thumbnails/gamethumbnail.png';
 import Project5Thumb from '../../assets/thumbnails/animationthumbnail.png';

--- a/frontend/src/shared/components/baseCard/baseCard.tsx
+++ b/frontend/src/shared/components/baseCard/baseCard.tsx
@@ -4,9 +4,6 @@ import './baseCard.css';
 import CardStyle1 from "../../../assets/sprites/FriedPeanuts-star.png";
 import CardStyle2 from "../../../assets/sprites/nicooooooo-brooch.png";
 import CardStyle3 from "../../../assets/sprites/nicooooooo-tail.png";
-import { InView } from 'react-intersection-observer';
-
-import FadeIn from '../../../components/fadeInSection/fadeInSection';
 
 export const CardStyles = [
     [CardStyle1, "var(--main-text-wrapper-background-color)"],
@@ -42,7 +39,6 @@ export default class BaseCard<T, P extends BaseCardProps<T>, S extends BaseCardS
     }
 
     public renderCard(content: JSX.Element): JSX.Element {
-        const { loaded } = this.state;
         const rootStyles: CSS.Properties = {
             backgroundImage: `url(${CardStyles[this.cardStyleIndex][0]})`,
         };

--- a/frontend/src/shared/components/baseSection/baseSection.tsx
+++ b/frontend/src/shared/components/baseSection/baseSection.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import AnnouncementCard from '../../../components/announcementSection/announcementCard';
-import { Announcement } from "../../../models/announcement";
 import { LanguageContext, LanguageContextValue } from "../../../components/languageSwitch/languageContext";
 import DisplayedLanguage from "../../../models/language";
 import { CardStyles } from "../../../shared/components/baseCard/baseCard";


### PR DESCRIPTION
- change `==` to `===` *(bruh.)*
- remove unused variables, types, and imports
- remove useless constructors
- (`jsx-a11y`) add `title` in `iframe`s and `alt` in `img`s

There is one warning left regarding an unused function, however I'll leave it there for now.