### PR TITLE
fix low horizontal res view of cards to not be so strange-looking

### DIFF
--- a/frontend/src/pages/home/home.css
+++ b/frontend/src/pages/home/home.css
@@ -41,10 +41,6 @@
     font-family: 'Indie Flower';
 }
 
-.wrapper-overlay {
-    padding: 2vh 4vw;
-}
-
 .main-video-container {
     width: 100%;
     box-sizing: border-box;

--- a/frontend/src/shared/components/baseCard/baseCard.css
+++ b/frontend/src/shared/components/baseCard/baseCard.css
@@ -79,6 +79,9 @@
 }
 
 @media (max-width: 400px) {
+    .card-section {
+        padding: 5px;
+    }
     .base-card {
         --card-text-width: 300px;
     }

--- a/frontend/src/shared/globalStyles/global.css
+++ b/frontend/src/shared/globalStyles/global.css
@@ -113,6 +113,12 @@
     }
 }
 
+@media (max-width: 300px) {
+    .wrapper-overlay {
+        padding: 0;
+    }
+}
+
 .line {
     height: 1px;
     background-color: white;


### PR DESCRIPTION
Apparently hunt's fix revealed maybe one of the reasons the overflow bug was present. I think using vw units caused some issues with divs inside 100% width divs. Will look into this more later.